### PR TITLE
feat: credibility scoring system

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { ReportModule } from './report/report.module';
 import { LineModule } from './line/line.module';
 import { UserModule } from './user/user.module';
 import { TransitModule } from './transit/transit.module';
+import { VoteModule } from './vote/vote.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { APP_GUARD } from '@nestjs/core';
 
@@ -20,6 +21,7 @@ import { APP_GUARD } from '@nestjs/core';
     LineModule,
     UserModule,
     TransitModule,
+    VoteModule,
   ],
   controllers: [AppController],
   providers: [AppService, { provide: APP_GUARD, useClass: JwtAuthGuard }],

--- a/apps/api/src/auth/strategies/supabase-jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/supabase-jwt.strategy.ts
@@ -22,7 +22,7 @@ export class SupabaseJwtStrategy extends PassportStrategy(
     const jwtSecret = process.env.SUPABASE_JWT_SECRET;
 
     if (supabaseUrl) {
-      // Project uses ES256 (JWKS-based verification)
+      // Supabase signs user JWTs with ES256 (JWKS-based verification)
       super({
         jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
         ignoreExpiration: false,

--- a/apps/api/src/report/report.module.ts
+++ b/apps/api/src/report/report.module.ts
@@ -6,9 +6,10 @@ import { PrismaReportRepository } from './repositories/prisma-report.repository'
 import { ReportExpiryJobService } from './report-expiry-job.service';
 import { REPORT_REPOSITORY } from './interfaces/report-repository.interface';
 import { AuthModule } from '../auth/auth.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [ScheduleModule.forRoot(), AuthModule],
+  imports: [ScheduleModule.forRoot(), AuthModule, UserModule],
   controllers: [ReportController],
   providers: [
     ReportService,

--- a/apps/api/src/report/report.service.spec.ts
+++ b/apps/api/src/report/report.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ReportService } from './report.service';
 import { IReportRepository } from './report-repository.interface';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../user/interfaces/user-repository.interface';
 import { ReportCategory } from '../../../../packages/shared/src/enums/report-category.enum';
 import type { Report } from '@prisma/client';
 
@@ -15,6 +19,16 @@ const mockRepo: jest.Mocked<IReportRepository> = {
   delete: jest.fn(),
 };
 
+const mockUserRepo: jest.Mocked<IUserRepository> = {
+  findById: jest.fn().mockResolvedValue({
+    id: 'user-uuid-1',
+    email: 'u@example.com',
+    credibilityScore: 0,
+    createdAt: new Date(),
+  }),
+  upsert: jest.fn(),
+};
+
 describe('ReportService', () => {
   let service: ReportService;
 
@@ -24,6 +38,7 @@ describe('ReportService', () => {
       providers: [
         ReportService,
         { provide: 'IReportRepository', useValue: mockRepo },
+        { provide: USER_REPOSITORY, useValue: mockUserRepo },
       ],
     }).compile();
 

--- a/apps/api/src/report/report.service.ts
+++ b/apps/api/src/report/report.service.ts
@@ -1,6 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 import type { Report } from '@prisma/client';
 import type { IReportRepository } from './report-repository.interface';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../user/interfaces/user-repository.interface';
 import { CreateReportDto } from './create-report.dto';
 import { EXPIRY_MINUTES } from './report-expiry.strategy';
 
@@ -9,11 +13,16 @@ export class ReportService {
   constructor(
     @Inject('IReportRepository')
     private readonly reportRepository: IReportRepository,
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
   ) {}
 
   async createReport(userId: string, dto: CreateReportDto): Promise<Report> {
     const expiresAt = new Date();
     expiresAt.setMinutes(expiresAt.getMinutes() + EXPIRY_MINUTES[dto.category]);
+
+    const author = await this.userRepository.findById(userId);
+    const authorScore = author?.credibilityScore ?? 0;
 
     return this.reportRepository.save({
       userId,
@@ -22,7 +31,7 @@ export class ReportService {
       category: dto.category,
       description: dto.description,
       photoUrl: dto.photoUrl,
-      credibilityScore: 5,
+      credibilityScore: 5 + authorScore,
       expiresAt,
     });
   }

--- a/apps/api/src/report/repositories/prisma-report.repository.spec.ts
+++ b/apps/api/src/report/repositories/prisma-report.repository.spec.ts
@@ -36,9 +36,8 @@ describe('PrismaReportRepository', () => {
       const result = await repo.findById('r1');
 
       expect(result).toBe(report);
-      expect(mockPrismaReport.findUnique).toHaveBeenCalledWith({
-        where: { id: 'r1' },
-      });
+      const [arg] = mockPrismaReport.findUnique.mock.calls[0];
+      expect(arg.where).toEqual({ id: 'r1' });
     });
 
     it('returns null when report does not exist', async () => {

--- a/apps/api/src/report/repositories/prisma-report.repository.ts
+++ b/apps/api/src/report/repositories/prisma-report.repository.ts
@@ -8,18 +8,25 @@ export class PrismaReportRepository implements IReportRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   findById(id: string): Promise<Report | null> {
-    return this.prisma.report.findUnique({ where: { id } });
+    return this.prisma.report.findUnique({
+      where: { id },
+      include: { user: { select: { id: true, credibilityScore: true } } },
+    });
   }
 
   findActiveByLine(lineId: string): Promise<Report[]> {
     return this.prisma.report.findMany({
       where: { lineId, status: 'active', expiresAt: { gt: new Date() } },
+      include: { user: { select: { id: true, credibilityScore: true } } },
+      orderBy: { credibilityScore: 'desc' },
     });
   }
 
   findActiveAll(): Promise<Report[]> {
     return this.prisma.report.findMany({
       where: { status: 'active', expiresAt: { gt: new Date() } },
+      include: { user: { select: { id: true, credibilityScore: true } } },
+      orderBy: { credibilityScore: 'desc' },
     });
   }
 

--- a/apps/api/src/vote/cast-vote.dto.ts
+++ b/apps/api/src/vote/cast-vote.dto.ts
@@ -1,0 +1,6 @@
+import { IsIn } from 'class-validator';
+
+export class CastVoteDto {
+  @IsIn(['confirm', 'dispute'])
+  type!: 'confirm' | 'dispute';
+}

--- a/apps/api/src/vote/interfaces/vote-repository.interface.ts
+++ b/apps/api/src/vote/interfaces/vote-repository.interface.ts
@@ -1,0 +1,11 @@
+import { Vote } from '@prisma/client';
+
+export interface IVoteRepository {
+  castVote(params: {
+    reportId: string;
+    userId: string;
+    type: 'confirm' | 'dispute';
+  }): Promise<{ vote: Vote; authorScore: number }>;
+}
+
+export const VOTE_REPOSITORY = 'IVoteRepository';

--- a/apps/api/src/vote/repositories/prisma-vote.repository.ts
+++ b/apps/api/src/vote/repositories/prisma-vote.repository.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
 import { Vote } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IVoteRepository } from '../interfaces/vote-repository.interface';

--- a/apps/api/src/vote/repositories/prisma-vote.repository.ts
+++ b/apps/api/src/vote/repositories/prisma-vote.repository.ts
@@ -1,0 +1,50 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Vote } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { IVoteRepository } from '../interfaces/vote-repository.interface';
+
+@Injectable()
+export class PrismaVoteRepository implements IVoteRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async castVote(params: {
+    reportId: string;
+    userId: string;
+    type: 'confirm' | 'dispute';
+  }): Promise<{ vote: Vote; authorScore: number }> {
+    const { reportId, userId, type } = params;
+
+    return this.prisma.$transaction(async (tx) => {
+      const report = await tx.report.findUnique({
+        where: { id: reportId },
+        select: { id: true, userId: true },
+      });
+      if (!report) throw new NotFoundException('Report not found');
+
+      const existing = await tx.vote.findUnique({
+        where: { reportId_userId: { reportId, userId } },
+      });
+      if (existing) throw new ConflictException('Already voted on this report');
+
+      const vote = await tx.vote.create({
+        data: { reportId, userId, type },
+      });
+
+      const delta = type === 'confirm' ? 1 : -1;
+      const author = await tx.user.findUnique({
+        where: { id: report.userId },
+        select: { credibilityScore: true },
+      });
+      const current = author?.credibilityScore ?? 0;
+      const next = Math.max(0, current + delta);
+
+      const updated = await tx.user.update({
+        where: { id: report.userId },
+        data: { credibilityScore: next },
+        select: { credibilityScore: true },
+      });
+
+      return { vote, authorScore: updated.credibilityScore };
+    });
+  }
+}

--- a/apps/api/src/vote/vote.controller.ts
+++ b/apps/api/src/vote/vote.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser, AuthUser } from '../auth/decorators/current-user.decorator';
+import { VoteService } from './vote.service';
+import { CastVoteDto } from './cast-vote.dto';
+
+@Controller('reports/:reportId/votes')
+export class VoteController {
+  constructor(private readonly voteService: VoteService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  async castVote(
+    @Param('reportId') reportId: string,
+    @CurrentUser() user: AuthUser,
+    @Body() dto: CastVoteDto,
+  ) {
+    return this.voteService.castVote(reportId, user.userId, dto.type);
+  }
+}

--- a/apps/api/src/vote/vote.controller.ts
+++ b/apps/api/src/vote/vote.controller.ts
@@ -1,6 +1,9 @@
 import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { CurrentUser, AuthUser } from '../auth/decorators/current-user.decorator';
+import {
+  CurrentUser,
+  AuthUser,
+} from '../auth/decorators/current-user.decorator';
 import { VoteService } from './vote.service';
 import { CastVoteDto } from './cast-vote.dto';
 

--- a/apps/api/src/vote/vote.module.ts
+++ b/apps/api/src/vote/vote.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { VoteController } from './vote.controller';
+import { VoteService } from './vote.service';
+import { PrismaVoteRepository } from './repositories/prisma-vote.repository';
+import { VOTE_REPOSITORY } from './interfaces/vote-repository.interface';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [VoteController],
+  providers: [
+    VoteService,
+    { provide: VOTE_REPOSITORY, useClass: PrismaVoteRepository },
+  ],
+})
+export class VoteModule {}

--- a/apps/api/src/vote/vote.service.ts
+++ b/apps/api/src/vote/vote.service.ts
@@ -1,5 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { IVoteRepository, VOTE_REPOSITORY } from './interfaces/vote-repository.interface';
+import {
+  IVoteRepository,
+  VOTE_REPOSITORY,
+} from './interfaces/vote-repository.interface';
 
 @Injectable()
 export class VoteService {

--- a/apps/api/src/vote/vote.service.ts
+++ b/apps/api/src/vote/vote.service.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IVoteRepository, VOTE_REPOSITORY } from './interfaces/vote-repository.interface';
+
+@Injectable()
+export class VoteService {
+  constructor(
+    @Inject(VOTE_REPOSITORY)
+    private readonly voteRepository: IVoteRepository,
+  ) {}
+
+  castVote(reportId: string, userId: string, type: 'confirm' | 'dispute') {
+    return this.voteRepository.castVote({ reportId, userId, type });
+  }
+}

--- a/apps/web/src/components/map/VehiclePopup.tsx
+++ b/apps/web/src/components/map/VehiclePopup.tsx
@@ -2,6 +2,7 @@ import { Popup } from 'react-leaflet';
 import { TRANSIT_COLORS } from '../../types/transit';
 import { useLines } from '../../hooks/useLines';
 import { useActiveReports } from '../../hooks/useActiveReports';
+import { getCredibilityTier, UNVERIFIED_THRESHOLD } from '../../lib/credibility';
 import type { VehiclePosition, TripTimeline } from '../../types/transit';
 
 const TYPE_LABELS: Record<string, string> = {
@@ -213,7 +214,11 @@ export default function VehiclePopup({ vehicle, timeline, loading, onClose }: Ve
               </span>
             </div>
             <div className="popup-scroll" style={{ padding: '0 16px 12px' }}>
-              {vehicleReports.map((report) => (
+              {vehicleReports.map((report) => {
+                const authorScore = report.user?.credibilityScore ?? 0;
+                const tier = getCredibilityTier(authorScore);
+                const unverified = authorScore < UNVERIFIED_THRESHOLD;
+                return (
                 <div
                   key={report.id}
                   style={{
@@ -228,8 +233,32 @@ export default function VehiclePopup({ vehicle, timeline, loading, onClose }: Ve
                     {CATEGORY_ICONS[report.category] ?? '\u{2139}\u{FE0F}'}
                   </span>
                   <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 12, fontWeight: 600, color: '#374151' }}>
-                      {CATEGORY_LABELS[report.category] ?? report.category}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                      <div style={{ fontSize: 12, fontWeight: 600, color: '#374151' }}>
+                        {CATEGORY_LABELS[report.category] ?? report.category}
+                      </div>
+                      <span style={{
+                        fontSize: 10,
+                        fontWeight: 600,
+                        color: tier.color,
+                        backgroundColor: tier.background,
+                        padding: '1px 6px',
+                        borderRadius: 999,
+                      }}>
+                        {tier.label}
+                      </span>
+                      {unverified && (
+                        <span style={{
+                          fontSize: 10,
+                          fontWeight: 500,
+                          color: '#9CA3AF',
+                          border: '1px solid #E5E7EB',
+                          padding: '1px 5px',
+                          borderRadius: 999,
+                        }}>
+                          Непотвърден
+                        </span>
+                      )}
                     </div>
                     {report.description && (
                       <div style={{
@@ -261,7 +290,8 @@ export default function VehiclePopup({ vehicle, timeline, loading, onClose }: Ve
                     />
                   )}
                 </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}

--- a/apps/web/src/components/profile/CredibilityCard.tsx
+++ b/apps/web/src/components/profile/CredibilityCard.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { transitApi } from '../../lib/transit-api';
+import { getCredibilityTier } from '../../lib/credibility';
+
+export default function CredibilityCard() {
+  const [score, setScore] = useState<number | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    transitApi
+      .getMe()
+      .then((me) => setScore(me.credibilityScore))
+      .catch(() => setError(true));
+  }, []);
+
+  const tier = score != null ? getCredibilityTier(score) : null;
+
+  return (
+    <div style={styles.card}>
+      <div style={styles.cardHeader}>
+        <ShieldCheck size={18} color="#1A1A2E" strokeWidth={2} />
+        <h2 style={styles.cardTitle}>Credibility</h2>
+      </div>
+
+      {error && <div style={styles.muted}>Could not load credibility.</div>}
+
+      {!error && (
+        <>
+          <div style={styles.scoreRow}>
+            <span style={styles.scoreLabel}>Score</span>
+            <span style={styles.scoreValue}>{score ?? '—'}</span>
+          </div>
+
+          <div style={styles.divider} />
+
+          <div style={styles.scoreRow}>
+            <span style={styles.scoreLabel}>Tier</span>
+            {tier ? (
+              <span
+                style={{
+                  ...styles.badge,
+                  color: tier.color,
+                  backgroundColor: tier.background,
+                }}
+              >
+                {tier.label}
+              </span>
+            ) : (
+              <span style={styles.muted}>—</span>
+            )}
+          </div>
+
+          <p style={styles.hint}>
+            Build credibility by submitting accurate reports that other
+            passengers confirm.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    border: '1px solid #E5E7EB',
+    boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+    padding: 24,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  cardHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 20,
+  },
+  cardTitle: {
+    margin: 0,
+    fontSize: 16,
+    fontWeight: 600,
+    color: '#1A1A2E',
+    letterSpacing: '-0.2px',
+  },
+  scoreRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '12px 0',
+  },
+  scoreLabel: {
+    fontSize: 12,
+    fontWeight: 500,
+    color: '#6B7280',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  scoreValue: {
+    fontSize: 20,
+    fontWeight: 600,
+    color: '#111827',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#E5E7EB',
+  },
+  badge: {
+    padding: '4px 10px',
+    borderRadius: 999,
+    fontSize: 13,
+    fontWeight: 600,
+  },
+  hint: {
+    margin: '12px 0 0 0',
+    fontSize: 13,
+    color: '#6B7280',
+    lineHeight: 1.4,
+  },
+  muted: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+};

--- a/apps/web/src/lib/credibility.ts
+++ b/apps/web/src/lib/credibility.ts
@@ -1,0 +1,20 @@
+export interface CredibilityTier {
+  label: string;
+  color: string;
+  background: string;
+}
+
+export function getCredibilityTier(score: number): CredibilityTier {
+  if (score >= 30) {
+    return { label: 'Доверен', color: '#B45309', background: '#FEF3C7' };
+  }
+  if (score >= 15) {
+    return { label: 'Надежден', color: '#15803D', background: '#DCFCE7' };
+  }
+  if (score >= 5) {
+    return { label: 'Активен', color: '#1D4ED8', background: '#DBEAFE' };
+  }
+  return { label: 'Нов потребител', color: '#6B7280', background: '#F3F4F6' };
+}
+
+export const UNVERIFIED_THRESHOLD = 3;

--- a/apps/web/src/lib/transit-api.ts
+++ b/apps/web/src/lib/transit-api.ts
@@ -72,4 +72,19 @@ export const transitApi = {
 
   deleteReport: (id: string) =>
     api.delete(`/reports/${id}`),
+
+  getMe: () =>
+    api
+      .get<{ id: string; email: string; credibilityScore: number; createdAt: string }>(
+        '/auth/me',
+      )
+      .then((r) => r.data),
+
+  voteOnReport: (reportId: string, type: 'confirm' | 'dispute') =>
+    api
+      .post<{ vote: { id: string; type: string }; authorScore: number }>(
+        `/reports/${reportId}/votes`,
+        { type },
+      )
+      .then((r) => r.data),
 };

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { supabase } from '../lib/supabase';
 import IdentityCard from '../components/profile/IdentityCard';
 import QuickSettings from '../components/profile/QuickSettings';
 import MyReportsCard from '../components/profile/MyReportsCard';
+import CredibilityCard from '../components/profile/CredibilityCard';
 
 export default function ProfilePage() {
   const navigate = useNavigate();
@@ -42,6 +43,7 @@ export default function ProfilePage() {
           <h1 style={styles.pageTitle}>Profile</h1>
           <div style={styles.grid}>
             <IdentityCard />
+            <CredibilityCard />
             <QuickSettings />
             <MyReportsCard />
           </div>

--- a/apps/web/src/types/transit.ts
+++ b/apps/web/src/types/transit.ts
@@ -96,6 +96,7 @@ export interface ActiveReport {
   status: string;
   createdAt: string;
   line?: TransitLine;
+  user?: { id: string; credibilityScore: number };
 }
 
 export const TRANSIT_COLORS: Record<string, string> = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,8 +1103,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -2577,7 +2576,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2625,7 +2623,6 @@
       "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2689,7 +2686,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
       "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2863,7 +2859,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4315,7 +4310,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4457,7 +4451,6 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -4487,7 +4480,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4549,7 +4541,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4703,7 +4694,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -5449,7 +5439,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5516,7 +5505,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5976,7 +5964,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6256,7 +6243,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6313,15 +6299,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7364,7 +7348,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7425,7 +7408,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7711,7 +7693,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8674,7 +8655,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9217,7 +9197,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -10270,8 +10249,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11064,7 +11042,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -11966,7 +11943,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -12102,7 +12078,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -12444,7 +12419,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12589,7 +12563,6 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -12850,7 +12823,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12860,7 +12832,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12996,8 +12967,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/remeda": {
       "version": "2.33.4",
@@ -13231,7 +13201,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14395,7 +14364,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14810,7 +14778,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14975,7 +14942,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15268,7 +15234,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -15406,7 +15371,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -15476,7 +15440,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15893,7 +15856,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/shared/src/enums/index.d.ts
+++ b/packages/shared/src/enums/index.d.ts
@@ -1,0 +1,3 @@
+export { ReportCategory } from './report-category.enum';
+export { ReportStatus } from './report-status.enum';
+export { VoteType } from './vote-type.enum';

--- a/packages/shared/src/enums/index.js
+++ b/packages/shared/src/enums/index.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.VoteType = exports.ReportStatus = exports.ReportCategory = void 0;
+var report_category_enum_1 = require("./report-category.enum");
+Object.defineProperty(exports, "ReportCategory", { enumerable: true, get: function () { return report_category_enum_1.ReportCategory; } });
+var report_status_enum_1 = require("./report-status.enum");
+Object.defineProperty(exports, "ReportStatus", { enumerable: true, get: function () { return report_status_enum_1.ReportStatus; } });
+var vote_type_enum_1 = require("./vote-type.enum");
+Object.defineProperty(exports, "VoteType", { enumerable: true, get: function () { return vote_type_enum_1.VoteType; } });
+//# sourceMappingURL=index.js.map

--- a/packages/shared/src/enums/index.js.map
+++ b/packages/shared/src/enums/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;AAAA,+DAAwD;AAA/C,sHAAA,cAAc,OAAA;AACvB,2DAAoD;AAA3C,kHAAA,YAAY,OAAA;AACrB,mDAA4C;AAAnC,0GAAA,QAAQ,OAAA"}

--- a/packages/shared/src/enums/report-category.enum.d.ts
+++ b/packages/shared/src/enums/report-category.enum.d.ts
@@ -1,0 +1,7 @@
+export declare enum ReportCategory {
+    VEHICLE_ISSUE = "VEHICLE_ISSUE",
+    TRAFFIC = "TRAFFIC",
+    INSPECTORS = "INSPECTORS",
+    SAFETY = "SAFETY",
+    OTHER = "OTHER"
+}

--- a/packages/shared/src/enums/report-category.enum.js
+++ b/packages/shared/src/enums/report-category.enum.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ReportCategory = void 0;
+var ReportCategory;
+(function (ReportCategory) {
+    ReportCategory["VEHICLE_ISSUE"] = "VEHICLE_ISSUE";
+    ReportCategory["TRAFFIC"] = "TRAFFIC";
+    ReportCategory["INSPECTORS"] = "INSPECTORS";
+    ReportCategory["SAFETY"] = "SAFETY";
+    ReportCategory["OTHER"] = "OTHER";
+})(ReportCategory || (exports.ReportCategory = ReportCategory = {}));
+//# sourceMappingURL=report-category.enum.js.map

--- a/packages/shared/src/enums/report-category.enum.js.map
+++ b/packages/shared/src/enums/report-category.enum.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"report-category.enum.js","sourceRoot":"","sources":["report-category.enum.ts"],"names":[],"mappings":";;;AAAA,IAAY,cAMX;AAND,WAAY,cAAc;IACxB,iDAA+B,CAAA;IAC/B,qCAAmB,CAAA;IACnB,2CAAyB,CAAA;IACzB,mCAAiB,CAAA;IACjB,iCAAe,CAAA;AACjB,CAAC,EANW,cAAc,8BAAd,cAAc,QAMzB"}

--- a/packages/shared/src/enums/report-status.enum.d.ts
+++ b/packages/shared/src/enums/report-status.enum.d.ts
@@ -1,0 +1,6 @@
+export declare enum ReportStatus {
+    ACTIVE = "active",
+    VERIFIED = "verified",
+    HIDDEN = "hidden",
+    EXPIRED = "expired"
+}

--- a/packages/shared/src/enums/report-status.enum.js
+++ b/packages/shared/src/enums/report-status.enum.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ReportStatus = void 0;
+var ReportStatus;
+(function (ReportStatus) {
+    ReportStatus["ACTIVE"] = "active";
+    ReportStatus["VERIFIED"] = "verified";
+    ReportStatus["HIDDEN"] = "hidden";
+    ReportStatus["EXPIRED"] = "expired";
+})(ReportStatus || (exports.ReportStatus = ReportStatus = {}));
+//# sourceMappingURL=report-status.enum.js.map

--- a/packages/shared/src/enums/report-status.enum.js.map
+++ b/packages/shared/src/enums/report-status.enum.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"report-status.enum.js","sourceRoot":"","sources":["report-status.enum.ts"],"names":[],"mappings":";;;AAAA,IAAY,YAKX;AALD,WAAY,YAAY;IACtB,iCAAiB,CAAA;IACjB,qCAAqB,CAAA;IACrB,iCAAiB,CAAA;IACjB,mCAAmB,CAAA;AACrB,CAAC,EALW,YAAY,4BAAZ,YAAY,QAKvB"}

--- a/packages/shared/src/enums/vote-type.enum.d.ts
+++ b/packages/shared/src/enums/vote-type.enum.d.ts
@@ -1,0 +1,4 @@
+export declare enum VoteType {
+    CONFIRM = "confirm",
+    DISPUTE = "dispute"
+}

--- a/packages/shared/src/enums/vote-type.enum.js
+++ b/packages/shared/src/enums/vote-type.enum.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.VoteType = void 0;
+var VoteType;
+(function (VoteType) {
+    VoteType["CONFIRM"] = "confirm";
+    VoteType["DISPUTE"] = "dispute";
+})(VoteType || (exports.VoteType = VoteType = {}));
+//# sourceMappingURL=vote-type.enum.js.map

--- a/packages/shared/src/enums/vote-type.enum.js.map
+++ b/packages/shared/src/enums/vote-type.enum.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"vote-type.enum.js","sourceRoot":"","sources":["vote-type.enum.ts"],"names":[],"mappings":";;;AAAA,IAAY,QAGX;AAHD,WAAY,QAAQ;IAClB,+BAAmB,CAAA;IACnB,+BAAmB,CAAA;AACrB,CAAC,EAHW,QAAQ,wBAAR,QAAQ,QAGnB"}


### PR DESCRIPTION
Track and surface user credibility based on peer votes. Votes on a report update the author's credibility in a single transaction (+1 confirm, -1 dispute, floor 0). New reports inherit the author's credibility into their initial score (5 + author). Reports are sorted by credibility so higher-trust reports surface first.

Frontend shows the user's score + tier on the profile page and a tier badge on report popups, with an 'Непотвърден' marker for low-credibility authors.