### PR TITLE
feat: implement LineModule and UserModule with full business logic

### DIFF
--- a/apps/api/src/line/line.controller.ts
+++ b/apps/api/src/line/line.controller.ts
@@ -1,7 +1,26 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { LineService } from './line.service';
+import { Public } from '../auth/decorators/public.decorator';
 
 @Controller('lines')
 export class LineController {
   constructor(private readonly lineService: LineService) {}
+
+  @Get()
+  @Public()
+  async findAll() {
+    return this.lineService.findAll();
+  }
+
+  @Get(':id')
+  @Public()
+  async findById(@Param('id') id: string) {
+    return this.lineService.findById(id);
+  }
+
+  @Get(':id/reports')
+  @Public()
+  async findReports(@Param('id') id: string) {
+    return this.lineService.findActiveReports(id);
+  }
 }

--- a/apps/api/src/line/line.module.ts
+++ b/apps/api/src/line/line.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { LineController } from './line.controller';
 import { LineService } from './line.service';
+import { ReportModule } from '../report/report.module';
 
 @Module({
+  imports: [ReportModule],
   controllers: [LineController],
   providers: [LineService],
 })

--- a/apps/api/src/line/line.service.ts
+++ b/apps/api/src/line/line.service.ts
@@ -1,4 +1,54 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ReportService } from '../report/report.service';
 
 @Injectable()
-export class LineService {}
+export class LineService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly reportService: ReportService,
+  ) {}
+
+  async findAll() {
+    return this.prisma.line.findMany({
+      orderBy: [{ type: 'asc' }, { name: 'asc' }],
+      select: { id: true, name: true, type: true },
+    });
+  }
+
+  async findById(id: string) {
+    const line = await this.prisma.line.findUnique({
+      where: { id },
+      include: {
+        lineStops: {
+          include: { stop: true },
+          orderBy: { stopOrder: 'asc' },
+        },
+      },
+    });
+    if (!line) throw new NotFoundException('Line not found');
+
+    return {
+      id: line.id,
+      name: line.name,
+      type: line.type,
+      stops: line.lineStops.map((ls) => ({
+        id: ls.stop.id,
+        name: ls.stop.name,
+        lat: ls.stop.lat,
+        lng: ls.stop.lng,
+        stopOrder: ls.stopOrder,
+      })),
+    };
+  }
+
+  async findActiveReports(lineId: string) {
+    const line = await this.prisma.line.findUnique({
+      where: { id: lineId },
+      select: { id: true },
+    });
+    if (!line) throw new NotFoundException('Line not found');
+
+    return this.reportService.getReportsByLine(lineId);
+  }
+}

--- a/apps/api/src/report/report.module.ts
+++ b/apps/api/src/report/report.module.ts
@@ -15,6 +15,6 @@ import { AuthModule } from '../auth/auth.module';
     ReportExpiryJobService,
     { provide: REPORT_REPOSITORY, useClass: PrismaReportRepository },
   ],
-  exports: [REPORT_REPOSITORY],
+  exports: [REPORT_REPOSITORY, ReportService],
 })
 export class ReportModule {}

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -1,7 +1,16 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Request } from '@nestjs/common';
 import { UserService } from './user.service';
+
+interface AuthenticatedRequest {
+  user: { userId: string; email: string };
+}
 
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
+
+  @Get('me/profile')
+  async getProfile(@Request() req: AuthenticatedRequest) {
+    return this.userService.getProfile(req.user.userId);
+  }
 }

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -10,6 +10,6 @@ import { USER_REPOSITORY } from './interfaces/user-repository.interface';
     UserService,
     { provide: USER_REPOSITORY, useClass: UserRepository },
   ],
-  exports: [USER_REPOSITORY],
+  exports: [USER_REPOSITORY, UserService],
 })
 export class UserModule {}

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,4 +1,39 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from './interfaces/user-repository.interface';
+
+export interface UserProfileDto {
+  id: string;
+  email: string;
+  credibilityScore: number;
+  reportCount: number;
+  createdAt: Date;
+}
 
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async getProfile(userId: string): Promise<UserProfileDto> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) throw new NotFoundException('User not found');
+
+    const reportCount = await this.prisma.report.count({
+      where: { userId },
+    });
+
+    return {
+      id: user.id,
+      email: user.email,
+      credibilityScore: user.credibilityScore,
+      reportCount,
+      createdAt: user.createdAt,
+    };
+  }
+}


### PR DESCRIPTION
Populates previously empty placeholder modules to match the documented architecture (Section 2.2, Table 14):

UserModule:
- UserService.getProfile() aggregates user record + report count
- GET /users/me/profile — JWT-protected, returns { id, email, credibilityScore, reportCount, createdAt }

LineModule:
- LineService wires PrismaService + ReportService
- GET /lines — public, returns all lines { id, name, type }
- GET /lines/:id — public, returns line with ordered stops[]
- GET /lines/:id/reports — public, delegates to ReportService.getReportsByLine()

ReportModule now exports ReportService so LineModule can consume it.