### PR TITLE
feat: voting system for reports

### DIFF
--- a/apps/api/src/auth/guards/optional-jwt-auth.guard.ts
+++ b/apps/api/src/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,19 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import type { Request } from 'express';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('supabase') {
+  canActivate(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest<Request>();
+    if (!req.headers.authorization) return true;
+    return super.canActivate(context);
+  }
+
+  handleRequest<TUser = unknown>(
+    _err: Error | null,
+    user: TUser | false,
+  ): TUser {
+    return (user || null) as TUser;
+  }
+}

--- a/apps/api/src/report/repositories/prisma-report.repository.spec.ts
+++ b/apps/api/src/report/repositories/prisma-report.repository.spec.ts
@@ -48,13 +48,13 @@ describe('PrismaReportRepository', () => {
   });
 
   describe('findActiveAll', () => {
-    it('queries with status=active and expiresAt > now', async () => {
+    it('queries visible statuses and expiresAt > now', async () => {
       mockPrismaReport.findMany.mockResolvedValue([]);
 
       await repo.findActiveAll();
 
       const [arg] = mockPrismaReport.findMany.mock.calls[0];
-      expect(arg.where.status).toBe('active');
+      expect(arg.where.status).toEqual({ in: ['active', 'verified'] });
       expect(arg.where.expiresAt).toHaveProperty('gt');
       expect(arg.where.expiresAt.gt).toBeInstanceOf(Date);
     });
@@ -68,7 +68,7 @@ describe('PrismaReportRepository', () => {
 
       const [arg] = mockPrismaReport.findMany.mock.calls[0];
       expect(arg.where.lineId).toBe('line-7');
-      expect(arg.where.status).toBe('active');
+      expect(arg.where.status).toEqual({ in: ['active', 'verified'] });
       expect(arg.where.expiresAt).toHaveProperty('gt');
     });
   });

--- a/apps/api/src/report/repositories/prisma-report.repository.ts
+++ b/apps/api/src/report/repositories/prisma-report.repository.ts
@@ -3,6 +3,21 @@ import { Report } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IReportRepository } from '../interfaces/report-repository.interface';
 
+const VISIBLE_STATUSES = ['active', 'verified'];
+
+function attachCounts<T extends Report & { votes?: { type: string }[] }>(
+  row: T,
+): Report & { confirms: number; disputes: number } {
+  const votes = row.votes ?? [];
+  const rest = { ...(row as Record<string, unknown>) };
+  delete rest.votes;
+  return {
+    ...(rest as unknown as Report),
+    confirms: votes.filter((v) => v.type === 'confirm').length,
+    disputes: votes.filter((v) => v.type === 'dispute').length,
+  };
+}
+
 @Injectable()
 export class PrismaReportRepository implements IReportRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -14,20 +29,35 @@ export class PrismaReportRepository implements IReportRepository {
     });
   }
 
-  findActiveByLine(lineId: string): Promise<Report[]> {
-    return this.prisma.report.findMany({
-      where: { lineId, status: 'active', expiresAt: { gt: new Date() } },
-      include: { user: { select: { id: true, credibilityScore: true } } },
+  async findActiveByLine(lineId: string): Promise<Report[]> {
+    const rows = await this.prisma.report.findMany({
+      where: {
+        lineId,
+        status: { in: VISIBLE_STATUSES },
+        expiresAt: { gt: new Date() },
+      },
+      include: {
+        user: { select: { id: true, credibilityScore: true } },
+        votes: { select: { type: true } },
+      },
       orderBy: { credibilityScore: 'desc' },
     });
+    return rows.map(attachCounts) as unknown as Report[];
   }
 
-  findActiveAll(): Promise<Report[]> {
-    return this.prisma.report.findMany({
-      where: { status: 'active', expiresAt: { gt: new Date() } },
-      include: { user: { select: { id: true, credibilityScore: true } } },
+  async findActiveAll(): Promise<Report[]> {
+    const rows = await this.prisma.report.findMany({
+      where: {
+        status: { in: VISIBLE_STATUSES },
+        expiresAt: { gt: new Date() },
+      },
+      include: {
+        user: { select: { id: true, credibilityScore: true } },
+        votes: { select: { type: true } },
+      },
       orderBy: { credibilityScore: 'desc' },
     });
+    return rows.map(attachCounts) as unknown as Report[];
   }
 
   save(data: {

--- a/apps/api/src/vote/interfaces/vote-repository.interface.ts
+++ b/apps/api/src/vote/interfaces/vote-repository.interface.ts
@@ -1,11 +1,30 @@
 import { Vote } from '@prisma/client';
 
+export interface VoteCounts {
+  confirms: number;
+  disputes: number;
+}
+
+export interface CastVoteResult {
+  vote: Vote;
+  reportCredibilityScore: number;
+  reportStatus: string;
+  counts: VoteCounts;
+}
+
 export interface IVoteRepository {
   castVote(params: {
     reportId: string;
     userId: string;
     type: 'confirm' | 'dispute';
-  }): Promise<{ vote: Vote; authorScore: number }>;
+  }): Promise<CastVoteResult>;
+
+  countVotes(reportId: string): Promise<VoteCounts>;
+
+  findUserVote(
+    reportId: string,
+    userId: string,
+  ): Promise<'confirm' | 'dispute' | null>;
 }
 
 export const VOTE_REPOSITORY = 'IVoteRepository';

--- a/apps/api/src/vote/repositories/prisma-vote.repository.ts
+++ b/apps/api/src/vote/repositories/prisma-vote.repository.ts
@@ -2,10 +2,17 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  ForbiddenException,
 } from '@nestjs/common';
-import { Vote } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
-import { IVoteRepository } from '../interfaces/vote-repository.interface';
+import {
+  CastVoteResult,
+  IVoteRepository,
+  VoteCounts,
+} from '../interfaces/vote-repository.interface';
+
+const VERIFIED_THRESHOLD = 2;
+const HIDDEN_THRESHOLD = 2;
 
 @Injectable()
 export class PrismaVoteRepository implements IVoteRepository {
@@ -15,15 +22,23 @@ export class PrismaVoteRepository implements IVoteRepository {
     reportId: string;
     userId: string;
     type: 'confirm' | 'dispute';
-  }): Promise<{ vote: Vote; authorScore: number }> {
+  }): Promise<CastVoteResult> {
     const { reportId, userId, type } = params;
 
     return this.prisma.$transaction(async (tx) => {
       const report = await tx.report.findUnique({
         where: { id: reportId },
-        select: { id: true, userId: true },
+        select: {
+          id: true,
+          userId: true,
+          credibilityScore: true,
+          status: true,
+        },
       });
       if (!report) throw new NotFoundException('Report not found');
+      if (report.userId === userId) {
+        throw new ForbiddenException('You cannot vote on your own report');
+      }
 
       const existing = await tx.vote.findUnique({
         where: { reportId_userId: { reportId, userId } },
@@ -35,20 +50,51 @@ export class PrismaVoteRepository implements IVoteRepository {
       });
 
       const delta = type === 'confirm' ? 1 : -1;
-      const author = await tx.user.findUnique({
-        where: { id: report.userId },
-        select: { credibilityScore: true },
-      });
-      const current = author?.credibilityScore ?? 0;
-      const next = Math.max(0, current + delta);
+      const nextCredibility = report.credibilityScore + delta;
 
-      const updated = await tx.user.update({
-        where: { id: report.userId },
-        data: { credibilityScore: next },
-        select: { credibilityScore: true },
+      const [confirms, disputes] = await Promise.all([
+        tx.vote.count({ where: { reportId, type: 'confirm' } }),
+        tx.vote.count({ where: { reportId, type: 'dispute' } }),
+      ]);
+
+      let nextStatus = report.status;
+      if (nextStatus === 'active' || nextStatus === 'verified') {
+        if (disputes >= HIDDEN_THRESHOLD) nextStatus = 'hidden';
+        else if (confirms >= VERIFIED_THRESHOLD) nextStatus = 'verified';
+      }
+
+      const updated = await tx.report.update({
+        where: { id: reportId },
+        data: { credibilityScore: nextCredibility, status: nextStatus },
+        select: { credibilityScore: true, status: true },
       });
 
-      return { vote, authorScore: updated.credibilityScore };
+      return {
+        vote,
+        reportCredibilityScore: updated.credibilityScore,
+        reportStatus: updated.status,
+        counts: { confirms, disputes },
+      };
     });
+  }
+
+  async countVotes(reportId: string): Promise<VoteCounts> {
+    const [confirms, disputes] = await Promise.all([
+      this.prisma.vote.count({ where: { reportId, type: 'confirm' } }),
+      this.prisma.vote.count({ where: { reportId, type: 'dispute' } }),
+    ]);
+    return { confirms, disputes };
+  }
+
+  async findUserVote(
+    reportId: string,
+    userId: string,
+  ): Promise<'confirm' | 'dispute' | null> {
+    const vote = await this.prisma.vote.findUnique({
+      where: { reportId_userId: { reportId, userId } },
+      select: { type: true },
+    });
+    if (!vote) return null;
+    return vote.type === 'confirm' ? 'confirm' : 'dispute';
   }
 }

--- a/apps/api/src/vote/vote.controller.ts
+++ b/apps/api/src/vote/vote.controller.ts
@@ -1,5 +1,15 @@
-import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 import {
   CurrentUser,
   AuthUser,
@@ -19,5 +29,15 @@ export class VoteController {
     @Body() dto: CastVoteDto,
   ) {
     return this.voteService.castVote(reportId, user.userId, dto.type);
+  }
+
+  @Get()
+  @UseGuards(OptionalJwtAuthGuard)
+  async getVotes(
+    @Param('reportId') reportId: string,
+    @Req() req: Request & { user?: AuthUser | null },
+  ) {
+    const userId = req.user?.userId ?? null;
+    return this.voteService.getVoteSummary(reportId, userId);
   }
 }

--- a/apps/api/src/vote/vote.service.ts
+++ b/apps/api/src/vote/vote.service.ts
@@ -14,4 +14,12 @@ export class VoteService {
   castVote(reportId: string, userId: string, type: 'confirm' | 'dispute') {
     return this.voteRepository.castVote({ reportId, userId, type });
   }
+
+  async getVoteSummary(reportId: string, userId: string | null) {
+    const counts = await this.voteRepository.countVotes(reportId);
+    const userVote = userId
+      ? await this.voteRepository.findUserVote(reportId, userId)
+      : null;
+    return { ...counts, userVote };
+  }
 }

--- a/apps/web/src/components/map/VehiclePopup.tsx
+++ b/apps/web/src/components/map/VehiclePopup.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react';
 import { Popup } from 'react-leaflet';
 import { TRANSIT_COLORS } from '../../types/transit';
 import { useLines } from '../../hooks/useLines';
-import { useActiveReports } from '../../hooks/useActiveReports';
+import { useActiveReports, triggerReportsRefetch } from '../../hooks/useActiveReports';
 import { getCredibilityTier, UNVERIFIED_THRESHOLD } from '../../lib/credibility';
-import type { VehiclePosition, TripTimeline } from '../../types/transit';
+import { transitApi } from '../../lib/transit-api';
+import type { VehiclePosition, TripTimeline, ActiveReport } from '../../types/transit';
 
 const TYPE_LABELS: Record<string, string> = {
   bus: 'Автобус',
@@ -17,6 +19,7 @@ interface VehiclePopupProps {
   timeline: TripTimeline | null;
   loading: boolean;
   onClose: () => void;
+  currentUserId?: string | null;
 }
 
 const CATEGORY_ICONS: Record<string, string> = {
@@ -35,6 +38,86 @@ const CATEGORY_LABELS: Record<string, string> = {
   OTHER: 'Друго',
 };
 
+function ReportVoteControls({
+  report,
+  canVote,
+}: {
+  report: ActiveReport;
+  canVote: boolean;
+}) {
+  const [confirms, setConfirms] = useState(report.confirms ?? 0);
+  const [disputes, setDisputes] = useState(report.disputes ?? 0);
+  const [userVote, setUserVote] = useState<'confirm' | 'dispute' | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function vote(type: 'confirm' | 'dispute') {
+    if (busy || userVote) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await transitApi.voteOnReport(report.id, type);
+      setConfirms(res.counts.confirms);
+      setDisputes(res.counts.disputes);
+      setUserVote(type);
+      triggerReportsRefetch();
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        setUserVote(type);
+      } else if (status === 403) {
+        setError('Не може да гласувате за свой доклад');
+      } else {
+        setError('Грешка при гласуване');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const btnStyle = (active: boolean, color: string): React.CSSProperties => ({
+    background: active ? color : '#F9FAFB',
+    color: active ? '#FFFFFF' : '#6B7280',
+    border: `1px solid ${active ? color : '#E5E7EB'}`,
+    borderRadius: 6,
+    padding: '2px 6px',
+    fontSize: 11,
+    fontWeight: 600,
+    cursor: canVote && !userVote && !busy ? 'pointer' : 'default',
+    opacity: !canVote ? 0.6 : 1,
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 3,
+    lineHeight: 1,
+  });
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+      <button
+        type="button"
+        onClick={() => canVote && vote('confirm')}
+        disabled={!canVote || !!userVote || busy}
+        style={btnStyle(userVote === 'confirm', '#16A34A')}
+        aria-label="Потвърди"
+      >
+        ↑ {confirms}
+      </button>
+      <button
+        type="button"
+        onClick={() => canVote && vote('dispute')}
+        disabled={!canVote || !!userVote || busy}
+        style={btnStyle(userVote === 'dispute', '#DC2626')}
+        aria-label="Оспори"
+      >
+        ↓ {disputes}
+      </button>
+      {error && (
+        <span style={{ fontSize: 10, color: '#DC2626' }}>{error}</span>
+      )}
+    </div>
+  );
+}
+
 function timeRemaining(expiresAt: string): string {
   const diff = new Date(expiresAt).getTime() - Date.now();
   if (diff <= 0) return 'изтекъл';
@@ -42,11 +125,12 @@ function timeRemaining(expiresAt: string): string {
   return `${mins} мин`;
 }
 
-export default function VehiclePopup({ vehicle, timeline, loading, onClose }: VehiclePopupProps) {
+export default function VehiclePopup({ vehicle, timeline, loading, onClose, currentUserId }: VehiclePopupProps) {
   const { linesByGtfsId } = useLines();
   const { reportsByVehicleId } = useActiveReports();
   const line = linesByGtfsId.get(vehicle.routeGtfsId);
-  const vehicleReports = reportsByVehicleId.get(vehicle.vehicleId) ?? [];
+  const rawReports = reportsByVehicleId.get(vehicle.vehicleId) ?? [];
+  const vehicleReports = rawReports.filter((r) => r.status !== 'hidden');
 
   const lineColor = timeline?.lineColor
     ? `#${timeline.lineColor}`
@@ -259,6 +343,21 @@ export default function VehiclePopup({ vehicle, timeline, loading, onClose }: Ve
                           Непотвърден
                         </span>
                       )}
+                      {report.status === 'verified' && (
+                        <span style={{
+                          fontSize: 10,
+                          fontWeight: 600,
+                          color: '#2563EB',
+                          backgroundColor: '#EFF6FF',
+                          padding: '1px 6px',
+                          borderRadius: 999,
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 2,
+                        }}>
+                          ✓ Потвърден
+                        </span>
+                      )}
                     </div>
                     {report.description && (
                       <div style={{
@@ -275,6 +374,10 @@ export default function VehiclePopup({ vehicle, timeline, loading, onClose }: Ve
                     <div style={{ fontSize: 10, color: '#9CA3AF', marginTop: 2 }}>
                       {timeRemaining(report.expiresAt)}
                     </div>
+                    <ReportVoteControls
+                      report={report}
+                      canVote={!!currentUserId && currentUserId !== report.userId}
+                    />
                   </div>
                   {report.photoUrl && (
                     <img

--- a/apps/web/src/lib/transit-api.ts
+++ b/apps/web/src/lib/transit-api.ts
@@ -82,9 +82,20 @@ export const transitApi = {
 
   voteOnReport: (reportId: string, type: 'confirm' | 'dispute') =>
     api
-      .post<{ vote: { id: string; type: string }; authorScore: number }>(
-        `/reports/${reportId}/votes`,
-        { type },
-      )
+      .post<{
+        vote: { id: string; type: string };
+        reportCredibilityScore: number;
+        reportStatus: string;
+        counts: { confirms: number; disputes: number };
+      }>(`/reports/${reportId}/votes`, { type })
+      .then((r) => r.data),
+
+  getReportVotes: (reportId: string) =>
+    api
+      .get<{
+        confirms: number;
+        disputes: number;
+        userVote: 'confirm' | 'dispute' | null;
+      }>(`/reports/${reportId}/votes`)
       .then((r) => r.data),
 };

--- a/apps/web/src/pages/MapPage.tsx
+++ b/apps/web/src/pages/MapPage.tsx
@@ -55,6 +55,7 @@ interface MapLayersProps {
   tripTimeline: ReturnType<typeof useTripTimeline>;
   onFollowChange: (following: boolean) => void;
   userLocation: { lat: number; lng: number; accuracy: number } | null;
+  currentUserId: string | null;
 }
 
 function MapLayers({
@@ -67,6 +68,7 @@ function MapLayers({
   tripTimeline,
   onFollowChange,
   userLocation,
+  currentUserId,
 }: MapLayersProps) {
   return (
     <>
@@ -98,6 +100,7 @@ function MapLayers({
           timeline={tripTimeline.timeline}
           loading={tripTimeline.loading}
           onClose={onDeselect}
+          currentUserId={currentUserId ?? null}
         />
       )}
 
@@ -220,6 +223,7 @@ export default function MapPage() {
             tripTimeline={tripTimeline}
             onFollowChange={handleFollowChange}
             userLocation={userLocation}
+            currentUserId={user?.id ?? null}
           />
         </MapContainer>
 

--- a/apps/web/src/types/transit.ts
+++ b/apps/web/src/types/transit.ts
@@ -95,6 +95,8 @@ export interface ActiveReport {
   expiresAt: string;
   status: string;
   createdAt: string;
+  confirms?: number;
+  disputes?: number;
   line?: TransitLine;
   user?: { id: string; credibilityScore: number };
 }


### PR DESCRIPTION
## Summary
- Users can confirm/dispute reports from the vehicle popup; one vote per user, no voting on your own report.
- Votes adjust report.credibility_score (+1/-1) and flip status to `verified` (2+ confirms) or `hidden` (2+ disputes); hidden reports are filtered from the UI and list endpoints.
- New `GET /reports/:id/votes` returns `{ confirms, disputes, userVote }` (optional auth); active report lists now include vote counts to avoid extra round-trips.

## Test plan
- [ ] Vote confirm/dispute from the map popup as a non-author
- [ ] Verify 403 when voting on your own report
- [ ] Verify 409 when voting twice
- [ ] Verify report flips to `verified` after 2 confirms (blue badge shows)
- [ ] Verify report disappears from the popup after 2 disputes
- [ ] Verify `credibility_score` updates correctly